### PR TITLE
chore(release): merge development into main — installation venv fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This format follows Keep a Changelog and uses Semantic Versioning.
 ### Fixed
 
 - Ensure update checks run on the first execution when no state file exists.
+- Harden installer venv setup to handle missing ensurepip/pip on Ubuntu 24 LTS.
+- Documented Ubuntu 24 LTS venv/pip installation recovery steps.
 
 ## [1.0.0] - 2026-01-31
 

--- a/docs/en/TROUBLESHOOTING.md
+++ b/docs/en/TROUBLESHOOTING.md
@@ -28,6 +28,22 @@ post_date: "2026-02-03"
 - Verify configuration:
   - `/opt/xnetvn_monitord/config/main.yaml`
 
+## 1.1 Installation fails with python3-venv or missing pip
+
+### Symptoms
+
+- `python3 -m venv` fails with `ensurepip is not available`.
+- The installer reports `/opt/xnetvn_monitord/.venv/bin/python: No module named pip`.
+
+### Fix
+
+- Install the venv package and re-run the installer:
+  - `sudo apt-get update && sudo apt-get install -y python3-venv`
+  - `sudo bash scripts/install.sh`
+- If the virtual environment already exists, remove it and reinstall:
+  - `sudo rm -rf /opt/xnetvn_monitord/.venv`
+  - `sudo bash scripts/install.sh`
+
 ## 2. Email/Telegram notifications are not sent
 
 ### Checks

--- a/docs/vi/TROUBLESHOOTING.md
+++ b/docs/vi/TROUBLESHOOTING.md
@@ -28,6 +28,22 @@ post_date: "2026-02-03"
 - Kiểm tra cấu hình:
   - `/opt/xnetvn_monitord/config/main.yaml`
 
+## 1.1 Lỗi cài đặt do thiếu python3-venv hoặc pip
+
+### Triệu chứng
+
+- `python3 -m venv` báo `ensurepip is not available`.
+- Trình cài đặt báo `/opt/xnetvn_monitord/.venv/bin/python: No module named pip`.
+
+### Cách xử lý
+
+- Cài gói venv và chạy lại trình cài đặt:
+  - `sudo apt-get update && sudo apt-get install -y python3-venv`
+  - `sudo bash scripts/install.sh`
+- Nếu virtual environment đã tồn tại, xóa và cài lại:
+  - `sudo rm -rf /opt/xnetvn_monitord/.venv`
+  - `sudo bash scripts/install.sh`
+
 ## 2. Không gửi được email/telegram
 
 ### Kiểm tra


### PR DESCRIPTION
Tóm tắt: Merge các thay đổi từ  vào \n\n- Thay đổi chính: Cải thiện script tạo venv để xử lý trường hợp /
Usage:   
  pip <command> [options]

Commands:
  install                     Install packages.
  download                    Download packages.
  uninstall                   Uninstall packages.
  freeze                      Output installed packages in requirements format.
  list                        List installed packages.
  show                        Show information about installed packages.
  check                       Verify installed packages have compatible dependencies.
  config                      Manage local and global configuration.
  search                      Search PyPI for packages.
  cache                       Inspect and manage pip's wheel cache.
  index                       Inspect information available from package indexes.
  wheel                       Build wheels from your requirements.
  hash                        Compute hashes of package archives.
  completion                  A helper command used for command completion.
  debug                       Show information useful for debugging.
  help                        Show help for commands.

General Options:
  -h, --help                  Show help.
  --debug                     Let unhandled exceptions propagate outside the
                              main subroutine, instead of logging them to
                              stderr.
  --isolated                  Run pip in an isolated mode, ignoring
                              environment variables and user configuration.
  --require-virtualenv        Allow pip to only run in a virtual environment;
                              exit with an error otherwise.
  -v, --verbose               Give more output. Option is additive, and can be
                              used up to 3 times.
  -V, --version               Show version and exit.
  -q, --quiet                 Give less output. Option is additive, and can be
                              used up to 3 times (corresponding to WARNING,
                              ERROR, and CRITICAL logging levels).
  --log <path>                Path to a verbose appending log.
  --no-input                  Disable prompting for input.
  --proxy <proxy>             Specify a proxy in the form
                              [user:passwd@]proxy.server:port.
  --retries <retries>         Maximum number of retries each connection should
                              attempt (default 5 times).
  --timeout <sec>             Set the socket timeout (default 15 seconds).
  --exists-action <action>    Default action when a path already exists:
                              (s)witch, (i)gnore, (w)ipe, (b)ackup, (a)bort.
  --trusted-host <hostname>   Mark this host or host:port pair as trusted,
                              even though it does not have valid or any HTTPS.
  --cert <path>               Path to PEM-encoded CA certificate bundle. If
                              provided, overrides the default. See 'SSL
                              Certificate Verification' in pip documentation
                              for more information.
  --client-cert <path>        Path to SSL client certificate, a single file
                              containing the private key and the certificate
                              in PEM format.
  --cache-dir <dir>           Store the cache data in <dir>.
  --no-cache-dir              Disable the cache.
  --disable-pip-version-check
                              Don't periodically check PyPI to determine
                              whether a new version of pip is available for
                              download. Implied with --no-index.
  --no-color                  Suppress colored output.
  --no-python-version-warning
                              Silence deprecation warnings for upcoming
                              unsupported Pythons.
  --use-feature <feature>     Enable new functionality, that may be backward
                              incompatible.
  --use-deprecated <feature>  Enable deprecated functionality, that will be
                              removed in the future. thiếu trên Ubuntu 24 LTS và thêm hướng dẫn phục hồi.\n- Kiểm tra cục bộ: ============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/udev/xdev/projects/githubcom/xnetvn-com/xnetvn_monitord
configfile: pytest.ini
testpaths: tests
plugins: freezegun-0.4.2, timeout-2.4.0, anyio-4.12.1, Faker-40.1.2, xdist-3.8.0, mock-3.15.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=strict, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 321 items

tests/integration/test_monitoring_workflow.py ....                       [  1%]
tests/unit/test_config_loader.py ...........................             [  9%]
tests/unit/test_daemon.py ..........................                     [ 17%]
tests/unit/test_discord_notifier.py ...........                          [ 21%]
tests/unit/test_email_notifier.py ................                       [ 26%]
tests/unit/test_notification_manager.py ................................ [ 36%]
..                                                                       [ 36%]
tests/unit/test_resource_monitor.py .................................... [ 47%]
..............                                                           [ 52%]
tests/unit/test_service_manager.py ....                                  [ 53%]
tests/unit/test_service_monitor.py ..................................... [ 65%]
.............................................................            [ 84%]
tests/unit/test_slack_notifier.py ...........                            [ 87%]
tests/unit/test_telegram_notifier.py ...................                 [ 93%]
tests/unit/test_update_checker.py ........                               [ 95%]
tests/unit/test_webhook_notifier.py .............                        [100%]

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.10.12-final-0 _______________

Name                                                 Stmts   Miss Branch BrPart   Cover   Missing
-------------------------------------------------------------------------------------------------
src/xnetvn_monitord/daemon.py                          242     21     78     16  85.94%   91->95, 160->163, 218-219, 252->255, 255->229, 274->229, 295->298, 307->310, 319->322, 332->323, 376->381, 381->386, 387-388, 390->exit, 400-401, 409-410, 413-441
src/xnetvn_monitord/monitors/resource_monitor.py       279     13     90     10  93.22%   76->80, 87->91, 95->105, 98->105, 144->152, 154->165, 259->261, 265, 320-324, 371, 380-382, 477-479
src/xnetvn_monitord/monitors/service_monitor.py        479     41    200     20  88.95%   147-149, 169-171, 286-287, 330-331, 358-372, 415->424, 420, 421->416, 476, 535-537, 667->688, 716->719, 750->753, 756, 800->789, 834->829, 945-946, 1025, 1034-1036, 1042-1044, 1046-1047, 1050-1057
src/xnetvn_monitord/notifiers/__init__.py              324      1    154     24  94.77%   178->185, 180->185, 185->192, 192->199, 201->206, 209->214, 240, 264->266, 298->304, 305->318, 312->318, 319->332, 326->332, 333->346, 340->346, 347->356, 350->356, 464->468, 480->486, 641->645, 645->649, 649->653, 653->657, 657->661
src/xnetvn_monitord/notifiers/discord_notifier.py       64      3     20      0  96.43%   129-131
src/xnetvn_monitord/notifiers/email_notifier.py        121      0     28      1  99.33%   70->74
src/xnetvn_monitord/notifiers/slack_notifier.py         70      3     24      0  96.81%   135-137
src/xnetvn_monitord/notifiers/telegram_notifier.py     114      7     34      0  95.27%   138-139, 151-152, 327-329
src/xnetvn_monitord/notifiers/webhook_notifier.py       75      4     24      1  94.95%   127, 141-143
src/xnetvn_monitord/utils/env_loader.py                 50     35     18      1  23.53%   39-41, 53-71, 89-108
src/xnetvn_monitord/utils/service_manager.py           131     33     42     13  71.10%   55, 76, 123, 128, 146, 148, 151, 167, 170, 188-213, 233, 264, 290->293, 297->300, 302->305, 306, 309, 312
src/xnetvn_monitord/utils/update_checker.py            216     56     60     14  69.57%   90-107, 139, 185, 197-199, 215, 236, 242-250, 256-257, 288-290, 329-330, 346-347, 352-353, 362->365, 376, 382-387, 401-408
-------------------------------------------------------------------------------------------------
TOTAL                                                 2229    217    786    100  87.56%

4 files skipped due to complete coverage.
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
Required test coverage of 85% reached. Total coverage: 87.56%
============================= 321 passed in 26.91s ============================= passed (321 passed), coverage = 87.56% (>=85%).\n\nHành động: Xin chờ CI (GitHub Actions). Nếu tất cả checks pass, xin reviewer/automation thực hiện merge theo chính sách dự án.