### PR TITLE
feat: add quarantine-based low disk cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+.worktrees/
 parts/
 sdist/
 var/

--- a/config/main.example.yaml
+++ b/config/main.example.yaml
@@ -648,8 +648,75 @@ resource_monitor:
     free_gb_threshold: 5.0
     # Minimum free MB threshold
     free_mb_threshold: 1024
-    # Action on low disk: notify, cleanup, both
+    # Action on low disk.
+    # Supported values:
+    #   - notify: keep the existing low-disk recovery flow without filesystem cleanup.
+    #   - cleanup: run the quarantine-based cleanup flow only.
+    #   - both: run quarantine-based cleanup first, then execute low_disk_services.
     action_on_threshold: "notify"
+
+    # Quarantine-first disk cleanup settings.
+    # Cleanup is only attempted when action_on_threshold is set to "cleanup" or "both".
+    cleanup:
+      # Enable or disable automatic cleanup for low-disk events.
+      enabled: false
+      # Cleanup mode.
+      # Supported values:
+      #   - quarantine_then_delete: move matching files/directories into quarantine first.
+      #     Permanent deletion must only happen later from inside quarantine.
+      mode: "quarantine_then_delete"
+      # Absolute path of the quarantine directory.
+      # This directory stores moved items plus JSON manifests used for restore operations.
+      quarantine_dir: "/opt/xnetvn_monitord/.local/quarantine"
+      # Allow directory candidates in addition to files.
+      # Supported values:
+      #   - false: only individual files may be quarantined.
+      #   - true: matched directories may also be quarantined as a whole tree.
+      allow_directories: false
+      # Hard cap on how many matching candidates one cleanup run may quarantine.
+      max_items_per_run: 100
+      # Hard cap on how long one cleanup scan may spend walking the filesystem.
+      # Keep this low to reduce CPU, I/O, and metadata pressure on busy servers.
+      max_runtime_seconds: 30
+
+      # Path selector rules.
+      # Matching is applied against normalized absolute paths.
+      selectors:
+        # Include selectors define which paths are eligible for cleanup.
+        include:
+          # Selector type.
+          # Supported values:
+          #   - exact: path must match the pattern exactly.
+          #   - regex: Python regular expression matched against the normalized absolute path.
+          #   - glob: shell-style glob matched against the normalized absolute path.
+          - type: "glob"
+            # Example: recursively match cache files below /var/cache/app.
+            pattern: "/var/cache/app/**/*.tmp"
+        # Exclude selectors short-circuit traversal and cleanup for matching paths.
+        exclude:
+          - type: "exact"
+            pattern: "/var/cache/app/keep"
+
+      # Candidate qualification rules.
+      rules:
+        # File system object types that may be quarantined.
+        # Supported values inside the list: file, directory
+        file_types:
+          - "file"
+        # Minimum candidate age in days based on last modification time.
+        min_age_days: 7
+        # Minimum candidate size in megabytes.
+        min_size_mb: 10
+
+      # Safety controls.
+      safety:
+        # Require the quarantine directory to live on the same filesystem device as the target mount.
+        # This keeps restore semantics predictable and avoids cross-device move surprises.
+        require_quarantine_same_filesystem: true
+        # Additional absolute paths that must never be scanned or quarantined.
+        # Built-in Linux safety paths are enforced automatically even when this list is empty.
+        protected_paths:
+          - "/var/lib/mysql"
 
   # Resource recovery actions
   recovery_actions:

--- a/docs/en/CONFIG.md
+++ b/docs/en/CONFIG.md
@@ -174,8 +174,16 @@ resource_monitor:
 
 - Both paths (string) and mount_points (dict) are supported for backward
   compatibility.
-- action_on_threshold appears in main.example.yaml but is not used in the
-  current codebase.
+- action_on_threshold is active and supports three values:
+  - notify: preserve the existing low-disk recovery flow without filesystem cleanup.
+  - cleanup: execute quarantine-based cleanup only.
+  - both: execute quarantine-based cleanup first, then restart low_disk_services.
+- disk.cleanup enables quarantine-first cleanup with exact/regex/glob selectors,
+  minimum age/size rules, protected path enforcement, same-filesystem quarantine
+  validation, and bounded scan limits for low server overhead.
+- Quarantined items are recorded in JSON manifests under the quarantine
+  directory so operators can restore one manifest or the full quarantine set
+  before any later purge step.
 
 ## recovery_actions
 
@@ -192,6 +200,8 @@ resource_monitor:
 
 - cooldown_period applies per action_type.
 - ResourceMonitor restarts services from these lists when thresholds are exceeded.
+- low_disk_services are executed for disk alerts in notify mode and after
+  cleanup in both mode.
 
 ## notifications
 

--- a/docs/superpowers/plans/2026-03-25-disk-cleanup-quarantine.md
+++ b/docs/superpowers/plans/2026-03-25-disk-cleanup-quarantine.md
@@ -1,0 +1,459 @@
+# Disk Cleanup Quarantine Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a production-safe disk cleanup workflow that quarantines matched files first, restores them exactly when requested, and only purges inside quarantine after retention checks.
+
+**Architecture:** `ResourceMonitor` remains the orchestrator for disk threshold actions while a new dedicated cleanup engine encapsulates selector matching, safety validation, quarantine movement, purge logic, manifest metadata, and restore support. The implementation prioritizes bounded work, same-filesystem moves, no symlink following, and explicit recovery tooling.
+
+**Tech Stack:** Python 3, pytest, psutil, pathlib/os/scandir, YAML config, Bash operator scripts.
+
+---
+
+## Context Map
+
+### Files to Modify
+
+| File | Purpose | Changes Needed |
+|------|---------|----------------|
+| `src/xnetvn_monitord/monitors/resource_monitor.py` | Resource threshold orchestration | Wire `disk.action_on_threshold`, invoke cleanup engine, aggregate cleanup and recovery results |
+| `config/main.example.yaml` | Canonical sample config | Add full cleanup/quarantine/restore config with detailed English comments and supported values |
+| `tests/unit/test_resource_monitor.py` | Existing disk monitor coverage | Extend orchestration tests for `notify`, `cleanup`, `both`, cooldown, and action aggregation |
+| `docs/en/CONFIG.md` | English config contract | Document cleanup configuration, restore semantics, and supported values |
+| `docs/vi/CONFIG.md` or equivalent Vietnamese config doc | Source-of-truth Vietnamese docs | Mirror the new config contract and safety guidance |
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/xnetvn_monitord/monitors/disk_cleanup.py` | Dedicated cleanup engine and data normalization helpers |
+| `tests/unit/test_disk_cleanup.py` | Unit coverage for selectors, scanning, quarantine, purge, restore metadata, and safety guards |
+| `scripts/restore_disk_cleanup.sh` | Operator-facing restore entrypoint with dry-run and filtering support |
+| `docs/superpowers/specs/2026-03-25-disk-cleanup-quarantine-design.md` | Approved design spec |
+
+### Dependencies (may need updates)
+
+| File | Relationship |
+|------|--------------|
+| `src/xnetvn_monitord/monitors/__init__.py` | May need export update if cleanup engine is shared/imported elsewhere |
+| `src/xnetvn_monitord/daemon.py` | Consumes `action_results`; verify no payload contract regressions |
+| `tests/conftest.py` | May add cleanup-specific fixtures or temporary filesystem helpers |
+| `scripts/run_tests.sh` | No direct change expected, but resulting tests must remain compatible |
+
+### Test Files
+
+| Test | Coverage |
+|------|----------|
+| `tests/unit/test_resource_monitor.py` | Disk threshold orchestration, action modes, cooldown, result aggregation |
+| `tests/unit/test_disk_cleanup.py` | Cleanup engine behavior, safety guards, manifest, restore, purge, low-I/O bounds |
+
+### Reference Patterns
+
+| File | Pattern |
+|------|---------|
+| `src/xnetvn_monitord/monitors/resource_monitor.py` | Existing action orchestration and structured action results |
+| `tests/unit/test_resource_monitor.py` | Existing TDD-style monitor coverage patterns |
+| `src/xnetvn_monitord/utils/update_checker.py` | Existing safety-oriented validation style for destructive archive handling |
+| `scripts/update.sh` | Operator-facing script conventions, safety prompts, and dry-run expectations |
+
+### Risk Assessment
+
+- [x] Breaking changes to public API: configuration contract expands; backward compatibility must be preserved
+- [ ] Database migrations needed
+- [x] Configuration changes required
+- [x] Operational scripts required
+- [x] Destructive behavior risk requires strict quarantine-first and restore path
+
+## Chunk 1: Cleanup Engine Contract
+
+### Task 1: Define cleanup engine public contract
+
+**Files:**
+- Create: `src/xnetvn_monitord/monitors/disk_cleanup.py`
+- Test: `tests/unit/test_disk_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests for config normalization and selector validation**
+
+Add tests for:
+
+```python
+def test_should_accept_exact_regex_and_glob_selectors():
+    ...
+
+def test_should_reject_invalid_selector_type():
+    ...
+
+def test_should_reject_invalid_regex_selector():
+    ...
+```
+
+- [ ] **Step 2: Run targeted tests to verify red state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: failures for missing module or missing helpers
+
+- [ ] **Step 3: Implement minimal cleanup config normalization layer**
+
+Implement typed/structured helpers that:
+
+- normalize include/exclude selectors
+- normalize supported enum values
+- merge built-in protected paths with configured ones
+- validate `mode == "quarantine_then_delete"`
+
+- [ ] **Step 4: Run targeted tests to verify green state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: new selector/config tests pass
+
+## Chunk 2: Safe Path Matching And Traversal
+
+### Task 2: Implement low-I/O candidate scanning with safety pruning
+
+**Files:**
+- Modify: `src/xnetvn_monitord/monitors/disk_cleanup.py`
+- Test: `tests/unit/test_disk_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests for path selection and pruning**
+
+Add tests for:
+
+```python
+def test_should_match_exact_path_case_sensitively():
+    ...
+
+def test_should_match_regex_against_normalized_absolute_path():
+    ...
+
+def test_should_match_glob_against_normalized_absolute_path():
+    ...
+
+def test_should_skip_excluded_paths_before_descending():
+    ...
+
+def test_should_skip_protected_paths():
+    ...
+
+def test_should_skip_symlink_targets():
+    ...
+
+def test_should_skip_paths_outside_mount_boundary():
+    ...
+```
+
+- [ ] **Step 2: Run targeted tests to verify red state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: traversal and safety tests fail
+
+- [ ] **Step 3: Implement streaming traversal**
+
+Implementation requirements:
+
+- use `os.scandir()`
+- prune excluded/protected directories before recursion
+- do not follow symlinks
+- optionally sort candidates lazily by configured strategy after bounded collection
+- stop when `max_items_per_run` or `max_runtime_seconds` is hit
+
+- [ ] **Step 4: Run targeted tests to verify green state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: selector and traversal tests pass
+
+## Chunk 3: Quarantine Movement And Manifest Metadata
+
+### Task 3: Quarantine matched items safely
+
+**Files:**
+- Modify: `src/xnetvn_monitord/monitors/disk_cleanup.py`
+- Test: `tests/unit/test_disk_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests for quarantine operations**
+
+Add tests for:
+
+```python
+def test_should_require_quarantine_on_same_filesystem_when_configured():
+    ...
+
+def test_should_move_file_into_quarantine_and_record_manifest():
+    ...
+
+def test_should_move_directory_into_quarantine_when_allowed():
+    ...
+
+def test_should_refuse_directory_quarantine_when_disallowed():
+    ...
+
+def test_should_preserve_original_path_in_manifest():
+    ...
+
+def test_should_not_fallback_to_direct_delete_when_quarantine_move_fails():
+    ...
+```
+
+- [ ] **Step 2: Run targeted tests to verify red state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: quarantine and manifest tests fail
+
+- [ ] **Step 3: Implement quarantine move and metadata recording**
+
+Implementation requirements:
+
+- generate stable item ids
+- create per-run manifest data
+- record original path, quarantine path, size, timestamps, selector match, and restore status
+- use same-filesystem move/rename semantics only when required by config
+
+- [ ] **Step 4: Run targeted tests to verify green state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: quarantine and manifest tests pass
+
+## Chunk 4: Purge Logic Inside Quarantine Only
+
+### Task 4: Add retention-based purge
+
+**Files:**
+- Modify: `src/xnetvn_monitord/monitors/disk_cleanup.py`
+- Test: `tests/unit/test_disk_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests for purge behavior**
+
+Add tests for:
+
+```python
+def test_should_purge_only_items_inside_quarantine():
+    ...
+
+def test_should_purge_items_older_than_retention():
+    ...
+
+def test_should_skip_non_manifested_items():
+    ...
+
+def test_should_support_dry_run_purge():
+    ...
+```
+
+- [ ] **Step 2: Run targeted tests to verify red state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: purge tests fail
+
+- [ ] **Step 3: Implement purge policy**
+
+Implementation requirements:
+
+- purge only quarantined items validated by manifest metadata
+- never purge live-path items
+- support retention by age and quarantine size policy
+- report reclaimed bytes and purge counts
+
+- [ ] **Step 4: Run targeted tests to verify green state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: purge tests pass
+
+## Chunk 5: Restore Support And Operator Scripts
+
+### Task 5: Add restore primitives and operator-facing script
+
+**Files:**
+- Modify: `src/xnetvn_monitord/monitors/disk_cleanup.py`
+- Create: `scripts/restore_disk_cleanup.sh`
+- Test: `tests/unit/test_disk_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests for restore semantics**
+
+Add tests for:
+
+```python
+def test_should_restore_item_to_exact_original_path():
+    ...
+
+def test_should_refuse_restore_when_destination_already_exists():
+    ...
+
+def test_should_support_restore_by_run_id():
+    ...
+
+def test_should_support_restore_dry_run():
+    ...
+```
+
+- [ ] **Step 2: Run targeted tests to verify red state**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: restore tests fail
+
+- [ ] **Step 3: Implement restore helper APIs and shell entrypoint**
+
+Script requirements:
+
+- `--dry-run`
+- `--run-id <id>`
+- `--item-id <id>`
+- `--all`
+- `--force` only for explicit overwrite behavior
+
+Implementation note:
+
+- if shell-only logic becomes brittle for manifest-safe parsing, keep shell as wrapper and call a Python entrypoint/helper for path-critical operations
+
+- [ ] **Step 4: Run targeted tests and shell lint**
+
+Run: `pytest tests/unit/test_disk_cleanup.py -q`
+Expected: restore tests pass
+
+Run: `shellcheck scripts/restore_disk_cleanup.sh`
+Expected: no issues
+
+## Chunk 6: ResourceMonitor Integration
+
+### Task 6: Wire cleanup engine into disk threshold actions
+
+**Files:**
+- Modify: `src/xnetvn_monitord/monitors/resource_monitor.py`
+- Modify: `tests/unit/test_resource_monitor.py`
+
+- [ ] **Step 1: Write the failing orchestration tests**
+
+Add tests for:
+
+```python
+def test_should_notify_only_when_disk_action_is_notify():
+    ...
+
+def test_should_run_cleanup_only_when_disk_action_is_cleanup():
+    ...
+
+def test_should_run_cleanup_then_service_recovery_when_disk_action_is_both():
+    ...
+
+def test_should_append_cleanup_action_results():
+    ...
+
+def test_should_respect_low_disk_cooldown_for_cleanup_and_recovery():
+    ...
+```
+
+- [ ] **Step 2: Run focused tests to verify red state**
+
+Run: `pytest tests/unit/test_resource_monitor.py -q`
+Expected: orchestration tests fail
+
+- [ ] **Step 3: Implement minimal integration**
+
+Implementation requirements:
+
+- read `disk.action_on_threshold`
+- call cleanup engine for `cleanup` and `both`
+- preserve threshold event behavior
+- preserve service recovery path for `both`
+- return structured action results usable by the daemon notification layer
+
+- [ ] **Step 4: Run focused tests to verify green state**
+
+Run: `pytest tests/unit/test_resource_monitor.py -q`
+Expected: all resource monitor tests pass
+
+## Chunk 7: Sample Config And Documentation
+
+### Task 7: Fully document the configuration and supported values
+
+**Files:**
+- Modify: `config/main.example.yaml`
+- Modify: `docs/en/CONFIG.md`
+- Modify: `docs/vi/CONFIG.md`
+
+- [ ] **Step 1: Write or update tests if config parsing behavior changes**
+
+If parsing helpers or defaults require tests, add/update:
+
+```python
+def test_should_accept_cleanup_config_defaults():
+    ...
+```
+
+- [ ] **Step 2: Update the example config with exhaustive English comments**
+
+Requirements:
+
+- document every new cleanup parameter
+- list every supported enum value inline
+- explain selector schema and examples for `exact`, `regex`, `glob`
+- explain quarantine, restore, retention, dry-run, and safety behavior
+
+- [ ] **Step 3: Update English and Vietnamese docs**
+
+Requirements:
+
+- document actual implemented behavior only
+- keep `docs/vi` aligned in meaning with `docs/en`
+- document restore script usage and operator safety expectations
+
+- [ ] **Step 4: Run relevant tests and spot-check docs accuracy**
+
+Run: `pytest tests/unit/test_config_loader.py -q`
+Expected: config-related tests pass
+
+## Chunk 8: Full Verification
+
+### Task 8: Run final verification before requesting implementation approval
+
+**Files:**
+- Modify: none expected unless verification reveals gaps
+
+- [ ] **Step 1: Run targeted unit tests for cleanup and resource monitor**
+
+Run: `pytest tests/unit/test_disk_cleanup.py tests/unit/test_resource_monitor.py -q`
+Expected: all tests pass
+
+- [ ] **Step 2: Run config-related tests**
+
+Run: `pytest tests/unit/test_config_loader.py -q`
+Expected: pass
+
+- [ ] **Step 3: Run formatting and lint checks for touched Python files**
+
+Run: `python -m black --check src tests`
+Expected: pass
+
+Run: `python -m isort --check-only src tests`
+Expected: pass
+
+Run: `python -m flake8 src tests`
+Expected: pass
+
+- [ ] **Step 4: Run typing check for touched Python modules**
+
+Run: `python -m mypy --install-types --non-interactive src`
+Expected: no new errors introduced by cleanup feature
+
+- [ ] **Step 5: Run shell lint for the restore script**
+
+Run: `shellcheck scripts/restore_disk_cleanup.sh`
+Expected: pass
+
+- [ ] **Step 6: Review requirements coverage manually**
+
+Checklist:
+
+- all selector types implemented
+- exclude patterns implemented
+- Ubuntu/system critical paths protected
+- low-resource scan strategy enforced
+- quarantine-first behavior enforced
+- restore scripts available
+- sample config fully documented in English
+- docs synchronized
+
+## Notes For Execution
+
+- Do not create a feature branch or worktree until the user approves this plan.
+- Do not implement direct-delete behavior outside quarantine.
+- If restore metadata format becomes complex, prefer a small Python helper over brittle shell parsing.
+- If runtime impact during tests exposes unacceptable cost, tighten bounds rather than broadening behavior.

--- a/docs/superpowers/specs/2026-03-25-disk-cleanup-quarantine-design.md
+++ b/docs/superpowers/specs/2026-03-25-disk-cleanup-quarantine-design.md
@@ -1,0 +1,375 @@
+# Disk Cleanup Quarantine Design
+
+## Summary
+
+This design adds a production-safe disk cleanup capability to `resource_monitor.disk`
+for `action_on_threshold: "cleanup"` and `action_on_threshold: "both"`.
+
+The feature is intentionally conservative:
+
+- It never deletes matched files directly from live locations.
+- It quarantines first, then purges only quarantined items after retention rules.
+- It keeps strict filesystem, path, and symlink safety boundaries.
+- It is optimized to minimize CPU, disk I/O, and latency impact on busy Linux servers.
+- It provides an explicit restore path via dedicated scripts and manifest metadata.
+
+## User-Approved Direction
+
+The approved operating mode is:
+
+- `quarantine_then_delete`
+
+This means:
+
+1. Candidate files or directories are discovered from configured include selectors.
+2. Protected or excluded paths are skipped.
+3. Eligible items are moved into a quarantine area together with metadata.
+4. Purge only happens inside quarantine after retention checks.
+5. Recovery scripts can restore quarantined items back to their original paths before purge.
+
+## Existing Codebase Findings
+
+Current repository behavior relevant to this feature:
+
+- `resource_monitor.disk.action_on_threshold` exists in `config/main.example.yaml` but is not consumed by the current Python implementation.
+- `ResourceMonitor._handle_low_disk()` only restarts configured services through `recovery_actions.low_disk_services`.
+- `ResourceMonitor` is already the orchestration point for CPU, memory, and disk threshold actions.
+- Tests already cover disk threshold evaluation, cooldown behavior, and action result aggregation.
+- No cleanup, quarantine, restore, or path-selector subsystem exists today.
+
+## Design Goals
+
+### Safety
+
+- Never directly delete live files outside quarantine.
+- Never follow symlinks during scan, quarantine, purge, or restore.
+- Never operate on protected system paths.
+- Never cross mount boundaries unexpectedly.
+- Never overwrite an existing destination during restore without an explicit safe policy.
+
+### Operational Stability
+
+- Keep monitoring loop impact bounded.
+- Use streaming directory iteration instead of loading large trees into memory.
+- Prefer same-filesystem rename/move semantics to avoid file copy overhead.
+- Stop early once enough free space is reclaimed or safety/runtime bounds are reached.
+
+### Auditability
+
+- Every quarantined item must have restorable metadata.
+- Every run must report scanned, matched, excluded, skipped, quarantined, purged, restored, errors, and reclaimed bytes.
+- Notifications and logs must describe what happened without leaking sensitive file contents.
+
+### Compatibility
+
+- Preserve current `notify` behavior.
+- Preserve current low-disk service restart behavior.
+- Keep backward compatibility for disk mount point config keys (`paths`, `mount_points`).
+
+## Proposed Architecture
+
+### 1. ResourceMonitor remains orchestration layer
+
+`ResourceMonitor` will:
+
+- evaluate disk thresholds
+- read `disk.action_on_threshold`
+- invoke a dedicated cleanup engine when cleanup is enabled
+- invoke low-disk service recovery when required by action mode
+- append structured action results for notifications
+
+### 2. Add a dedicated cleanup engine module
+
+Create a focused module under `src/xnetvn_monitord/monitors/` to keep responsibilities separated from `ResourceMonitor`.
+
+Planned responsibilities:
+
+- configuration normalization and validation
+- selector matching (`exact`, `regex`, `glob`)
+- safe candidate scanning
+- protected path enforcement
+- same-filesystem quarantine movement
+- retention-based purge inside quarantine
+- manifest generation and reading
+- restore support primitives shared with restore scripts
+
+### 3. Add restore scripts
+
+Dedicated scripts will restore quarantined items back to their original locations using manifest data.
+
+The scripts will:
+
+- read quarantine metadata only
+- validate target safety before restore
+- refuse destructive overwrite by default
+- restore exact original absolute paths
+- support dry-run preview
+- support restoring one item, all items, or filtered subsets
+
+## Configuration Contract
+
+### Top-Level Disk Action
+
+Supported values for `resource_monitor.disk.action_on_threshold`:
+
+- `notify`: send threshold notifications only
+- `cleanup`: run cleanup only
+- `both`: run cleanup first, then run low-disk recovery services if configured
+
+### Cleanup Block
+
+Proposed structure:
+
+```yaml
+resource_monitor:
+  disk:
+    action_on_threshold: "both"
+    cleanup:
+      enabled: true
+      mode: "quarantine_then_delete"
+      quarantine_dir: "/opt/xnetvn_monitord/.local/quarantine/disk_cleanup"
+      stop_when_threshold_cleared: true
+      minimum_reclaimed_mb: 512
+      max_items_per_run: 500
+      max_runtime_seconds: 120
+      follow_symlinks: false
+      continue_on_error: true
+      dry_run: false
+      sort_by: "largest_first"
+      allow_directories: true
+      selectors:
+        include: []
+        exclude: []
+      rules:
+        file_types: ["file", "directory"]
+        min_age_days: 7
+        min_size_mb: 10
+        empty_dirs_only: false
+      retention:
+        quarantine_max_age_days: 14
+        quarantine_max_size_mb: 2048
+      safety:
+        require_same_filesystem_as_mount_point: true
+        require_quarantine_same_filesystem: true
+        protected_paths: []
+        protected_patterns: []
+```
+
+## Selector Types
+
+Each selector item supports:
+
+- `type: "exact"`
+- `type: "regex"`
+- `type: "glob"`
+
+Each selector also has:
+
+- `pattern`: matching expression
+
+Matching rules:
+
+- `exact` is case-sensitive and must match the normalized absolute path exactly.
+- `regex` is matched against the normalized absolute path.
+- `glob` uses shell-style glob matching against the normalized absolute path.
+
+## Protected Path Policy
+
+The feature must ship with hard-coded default protected paths for Linux, especially Ubuntu.
+
+Minimum built-in defaults:
+
+- `/`
+- `/boot`
+- `/etc`
+- `/usr`
+- `/var/lib`
+- `/var/lib/dpkg`
+- `/var/lib/systemd`
+- `/var/log/journal`
+- `/proc`
+- `/sys`
+- `/dev`
+- `/run`
+- `/snap`
+
+These built-ins should be merged with user-configured protected lists, not replaced by them.
+
+## Low-Resource Execution Strategy
+
+The user's requirement to minimize server resource usage is valid and should be mandatory.
+
+Implementation policy:
+
+- use `os.scandir()` for streaming traversal
+- prune excluded or protected directories before descending
+- avoid content hashing, compression, checksum passes, or archive creation
+- avoid cross-filesystem copies by requiring quarantine on the same filesystem
+- prefer atomic rename/move operations when possible
+- evaluate files lazily and stop once reclaim target or threshold recovery is reached
+- enforce `max_items_per_run` and `max_runtime_seconds`
+- avoid changing process niceness for the whole daemon because that could affect unrelated monitor work; instead rely on bounded work and I/O-efficient operations
+
+This is safer than trying to globally `nice` or `ionice` the daemon process, which can have uneven behavior and may require privileges not guaranteed in production.
+
+## Quarantine Metadata Design
+
+Each quarantined item requires metadata sufficient for exact restore.
+
+Required fields:
+
+- item identifier
+- original absolute path
+- quarantine absolute path
+- mount point
+- item type (`file` or `directory`)
+- selector type and matched pattern
+- size in bytes
+- timestamps captured at quarantine time
+- cleanup run id
+- restore status
+
+Metadata storage proposal:
+
+- one manifest file per cleanup run under the quarantine root
+- one metadata file per quarantined item if needed for easier restore and audit
+
+This allows fast listing and exact restore without rescanning live trees.
+
+## Restore Script Design
+
+The user's request for restore scripts is valid and strongly recommended.
+
+Required behavior:
+
+- restore exact original paths
+- support dry-run
+- support restoring by run id
+- support restoring a single item id
+- support restoring all non-purged items
+- refuse overwrite when destination already exists unless an explicit force flag is given
+- validate parent directory creation safely
+- validate that restore source is inside the configured quarantine root
+
+Recommended scripts:
+
+- `scripts/restore_disk_cleanup.sh`: operator-facing wrapper
+- optional Python helper invoked by the shell script for manifest-safe path handling if shell alone becomes too fragile
+
+## Detailed Commenting Requirement For main.example.yaml
+
+The user's requirement to document every parameter and every supported value in `main.example.yaml` is reasonable.
+
+Guidance:
+
+- document all new cleanup parameters in English only
+- explicitly list supported enum values next to each enum field
+- document selector item schema and examples for `exact`, `regex`, and `glob`
+- document restore script usage references where appropriate
+- explain default safe behavior and why direct deletion is not the default
+
+This will enlarge the sample config, but that tradeoff is justified because the feature is destructive if misconfigured.
+
+## Action Ordering
+
+When disk threshold is exceeded:
+
+1. collect disk result
+2. emit threshold event as today
+3. if mode is `cleanup` or `both`, attempt cleanup
+4. if mode is `both`, optionally run low-disk service restarts after cleanup
+5. emit structured action result for cleanup and, if applicable, service recovery
+
+Rationale:
+
+- cleanup may already reclaim enough space, making service restart unnecessary in some deployments
+- preserving ordered action results improves observability
+
+## Error Handling Strategy
+
+- invalid selector regex should fail configuration validation for that cleanup run and report a structured error
+- path permission errors should be recorded per item and should not crash the whole monitoring cycle
+- quarantine move failures should not trigger direct delete fallback
+- restore failures should preserve quarantine state for retry
+- purge only occurs inside quarantine and only after metadata validation
+
+## Testing Strategy
+
+Mandatory coverage areas:
+
+1. selector matching
+2. include/exclude precedence
+3. protected path blocking
+4. symlink blocking
+5. same-filesystem enforcement
+6. quarantine manifest creation
+7. restore exact original path
+8. restore collision refusal
+9. bounded scan runtime and item count
+10. `notify`, `cleanup`, and `both` orchestration modes
+11. retention purge only inside quarantine
+12. dry-run behavior
+
+## Risks And Mitigations
+
+### Risk: directory traversal or symlink escape
+
+Mitigation:
+
+- realpath normalization
+- no symlink following
+- quarantine root containment checks
+
+### Risk: heavy I/O on busy servers
+
+Mitigation:
+
+- same-filesystem rename only
+- bounded batch execution
+- early stop after reclaim target
+- streaming traversal
+
+### Risk: restoring over live files
+
+Mitigation:
+
+- no overwrite by default
+- explicit operator confirmation through script flags
+
+### Risk: deleting critical Ubuntu state
+
+Mitigation:
+
+- hard-coded protected defaults
+- user-configurable additional protected paths and patterns
+- quarantine-first policy
+
+## Files Expected To Change
+
+Core code:
+
+- `src/xnetvn_monitord/monitors/resource_monitor.py`
+- new cleanup engine module under `src/xnetvn_monitord/monitors/`
+
+Tests:
+
+- `tests/unit/test_resource_monitor.py`
+- new cleanup-focused unit test file under `tests/unit/`
+
+Ops and config:
+
+- `config/main.example.yaml`
+- new restore script under `scripts/`
+
+Docs:
+
+- `docs/en/CONFIG.md`
+- matching Vietnamese documentation under `docs/vi/`
+
+Future customization updates after implementation:
+
+- relevant repository instructions and skill files describing safe disk cleanup conventions
+
+## Decision
+
+Proceed with a dedicated cleanup engine, quarantine-first restore-capable workflow, low-I/O scanning policy, and explicit restore scripts.

--- a/docs/vi/CONFIG.md
+++ b/docs/vi/CONFIG.md
@@ -172,8 +172,15 @@ resource_monitor:
 ```
 
 - Hỗ trợ paths (chuỗi) và mount_points (dict) để tương thích cấu hình cũ.
-- action_on_threshold xuất hiện trong main.example.yaml nhưng chưa được sử dụng
-  trong mã nguồn hiện tại.
+- action_on_threshold đã được kích hoạt và hỗ trợ ba giá trị:
+  - notify: giữ luồng low-disk recovery hiện có, không dọn dẹp filesystem.
+  - cleanup: chỉ chạy cleanup theo cơ chế quarantine.
+  - both: chạy cleanup theo cơ chế quarantine trước, sau đó restart low_disk_services.
+- disk.cleanup hỗ trợ cleanup theo kiểu quarantine-first với bộ lọc exact/regex/glob,
+  điều kiện tuổi/kích thước tối thiểu, danh sách protected paths, kiểm tra cùng
+  filesystem cho quarantine, và giới hạn thời gian quét để giảm tải server.
+- Các mục bị quarantine được ghi vào JSON manifest trong quarantine directory để
+  operator có thể restore theo từng manifest hoặc restore toàn bộ trước khi purge.
 
 ## recovery_actions
 
@@ -190,6 +197,8 @@ resource_monitor:
 
 - cooldown_period áp dụng cho từng action_type.
 - ResourceMonitor sẽ restart services theo danh sách này khi vượt ngưỡng.
+- low_disk_services sẽ chạy cho cảnh báo disk ở chế độ notify và sẽ chạy sau
+  cleanup ở chế độ both.
 
 ## notifications
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -545,8 +545,11 @@ copy_files() {
     if [ -f "$SOURCE_DIR/scripts/update.sh" ]; then
         mkdir -p "$INSTALL_DIR/scripts"
         cp "$SOURCE_DIR/scripts/update.sh" "$INSTALL_DIR/scripts/update.sh"
+        cp "$SOURCE_DIR/scripts/restore_quarantine.sh" "$INSTALL_DIR/scripts/restore_quarantine.sh"
         chmod 755 "$INSTALL_DIR/scripts/update.sh"
+        chmod 755 "$INSTALL_DIR/scripts/restore_quarantine.sh"
         log_info "Update script copied to $INSTALL_DIR/scripts/update.sh"
+        log_info "Restore script copied to $INSTALL_DIR/scripts/restore_quarantine.sh"
     else
         log_warning "Update script not found in source"
     fi

--- a/scripts/restore_quarantine.sh
+++ b/scripts/restore_quarantine.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 xNetVN Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+INSTALL_DIR_DEFAULT="/opt/xnetvn_monitord"
+INSTALL_DIR="${XNETVN_MONITORD_HOME:-$INSTALL_DIR_DEFAULT}"
+QUARANTINE_DIR="${INSTALL_DIR}/.local/quarantine"
+MANIFEST_PATH=""
+DRY_RUN=false
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/restore_quarantine.sh [options]
+
+Options:
+  --install-dir PATH     Override install directory (default: /opt/xnetvn_monitord)
+  --quarantine-dir PATH  Override quarantine directory
+  --manifest PATH        Restore only one manifest instead of all manifests
+  --dry-run              Report restore targets without moving files
+  --help                 Show this help
+USAGE
+}
+
+log_info() {
+    echo "[INFO] $1"
+}
+
+log_error() {
+    echo "[ERROR] $1" >&2
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --install-dir)
+                INSTALL_DIR="$2"
+                shift 2
+                ;;
+            --install-dir=*)
+                INSTALL_DIR="${1#*=}"
+                shift
+                ;;
+            --quarantine-dir)
+                QUARANTINE_DIR="$2"
+                shift 2
+                ;;
+            --quarantine-dir=*)
+                QUARANTINE_DIR="${1#*=}"
+                shift
+                ;;
+            --manifest)
+                MANIFEST_PATH="$2"
+                shift 2
+                ;;
+            --manifest=*)
+                MANIFEST_PATH="${1#*=}"
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                log_error "Unknown argument: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    log_error "python3 is required"
+    exit 1
+fi
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    log_error "Install directory not found: $INSTALL_DIR"
+    exit 1
+fi
+
+if [ ! -d "$INSTALL_DIR/xnetvn_monitord" ]; then
+    log_error "Installed Python package not found: $INSTALL_DIR/xnetvn_monitord"
+    exit 1
+fi
+
+if [ -n "$MANIFEST_PATH" ] && [ ! -f "$MANIFEST_PATH" ]; then
+    log_error "Manifest file not found: $MANIFEST_PATH"
+    exit 1
+fi
+
+if [ -z "$MANIFEST_PATH" ] && [ ! -d "$QUARANTINE_DIR" ]; then
+    log_error "Quarantine directory not found: $QUARANTINE_DIR"
+    exit 1
+fi
+
+PYTHONPATH="$INSTALL_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+XNETVN_MONITORD_QUARANTINE_DIR="$QUARANTINE_DIR" \
+XNETVN_MONITORD_MANIFEST_PATH="$MANIFEST_PATH" \
+XNETVN_MONITORD_DRY_RUN="$DRY_RUN" \
+python3 - <<'PY'
+import json
+import os
+
+from xnetvn_monitord.monitors.disk_cleanup import restore_quarantine_directory
+from xnetvn_monitord.monitors.disk_cleanup import restore_quarantine_manifest
+
+
+def main() -> int:
+    quarantine_dir = os.environ["XNETVN_MONITORD_QUARANTINE_DIR"]
+    manifest_path = os.environ.get("XNETVN_MONITORD_MANIFEST_PATH", "")
+    dry_run = os.environ.get("XNETVN_MONITORD_DRY_RUN", "false").lower() == "true"
+
+    if manifest_path:
+        result = restore_quarantine_manifest(manifest_path, dry_run=dry_run)
+    else:
+        result = restore_quarantine_directory(quarantine_dir, dry_run=dry_run)
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result.get("errors") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY

--- a/src/xnetvn_monitord/monitors/disk_cleanup.py
+++ b/src/xnetvn_monitord/monitors/disk_cleanup.py
@@ -1,0 +1,405 @@
+# Copyright 2026 xNetVN Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Disk cleanup configuration helpers.
+
+This module starts with normalization and validation primitives used by the
+future quarantine-based disk cleanup engine.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import shutil
+import time
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+SUPPORTED_SELECTOR_TYPES = {"exact", "regex", "glob"}
+
+DEFAULT_PROTECTED_PATHS = (
+    "/",
+    "/boot",
+    "/dev",
+    "/etc",
+    "/proc",
+    "/run",
+    "/snap",
+    "/sys",
+    "/usr",
+    "/var/lib",
+    "/var/lib/dpkg",
+    "/var/lib/systemd",
+    "/var/log/journal",
+)
+
+
+def normalize_cleanup_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize cleanup configuration and validate selector inputs.
+
+    Args:
+        config: Cleanup configuration fragment from the disk monitor settings.
+
+    Returns:
+        A normalized configuration dictionary with merged default safety rules.
+
+    Raises:
+        ValueError: If the cleanup mode, selector type, or selector regex is invalid.
+    """
+    normalized = deepcopy(config)
+    mode = normalized.get("mode", "quarantine_then_delete")
+    if mode != "quarantine_then_delete":
+        raise ValueError("Unsupported cleanup mode: %s" % mode)
+
+    selectors = normalized.setdefault("selectors", {})
+    selectors["include"] = _normalize_selectors(selectors.get("include", []))
+    selectors["exclude"] = _normalize_selectors(selectors.get("exclude", []))
+    normalized.setdefault("allow_directories", False)
+
+    safety = normalized.setdefault("safety", {})
+    configured_paths = safety.get("protected_paths", []) or []
+    merged_paths = list(dict.fromkeys([*DEFAULT_PROTECTED_PATHS, *configured_paths]))
+    safety["protected_paths"] = merged_paths
+    safety.setdefault("require_quarantine_same_filesystem", True)
+
+    return normalized
+
+
+def _normalize_selectors(selectors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Validate selector definitions and normalize supported selector items."""
+    normalized_selectors: List[Dict[str, Any]] = []
+
+    for selector in selectors:
+        selector_type = selector.get("type")
+        pattern = selector.get("pattern")
+
+        if selector_type not in SUPPORTED_SELECTOR_TYPES:
+            raise ValueError("Unsupported selector type: %s" % selector_type)
+        if not isinstance(pattern, str) or not pattern:
+            raise ValueError("Selector pattern must be a non-empty string")
+
+        if selector_type == "regex":
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError("Invalid regex selector: %s" % pattern) from exc
+
+        normalized_selectors.append({"type": selector_type, "pattern": pattern})
+
+    return normalized_selectors
+
+
+def path_matches_selector(path: str, selector: Dict[str, str]) -> bool:
+    """Check whether an absolute path matches a selector definition."""
+    normalized_path = os.path.normpath(path)
+    selector_type = selector["type"]
+    pattern = selector["pattern"]
+
+    if selector_type == "exact":
+        return normalized_path == os.path.normpath(pattern)
+    if selector_type == "regex":
+        return re.search(pattern, normalized_path) is not None
+    if selector_type == "glob":
+        normalized_pattern = os.path.normpath(pattern)
+        if fnmatch.fnmatchcase(normalized_path, normalized_pattern):
+            return True
+        if normalized_pattern.endswith(f"{os.sep}**"):
+            recursive_root = normalized_pattern[: -(len(os.sep) + 2)]
+            return normalized_path == recursive_root or normalized_path.startswith(f"{recursive_root}{os.sep}")
+        return False
+
+    raise ValueError("Unsupported selector type: %s" % selector_type)
+
+
+def scan_cleanup_candidates(
+    mount_point: str,
+    cleanup_config: Dict[str, Any],
+    current_time: Optional[float] = None,
+) -> List[Dict[str, Any]]:
+    """Stream cleanup candidates for a mount point with conservative safety checks."""
+    normalized_mount_point = os.path.realpath(mount_point)
+    now = time.time() if current_time is None else current_time
+    selectors = cleanup_config.get("selectors", {})
+    include_selectors = selectors.get("include", [])
+    exclude_selectors = selectors.get("exclude", [])
+    safety = cleanup_config.get("safety", {})
+    protected_paths = {os.path.realpath(path) for path in safety.get("protected_paths", [])}
+    rules = cleanup_config.get("rules", {})
+    file_types = set(rules.get("file_types", ["file", "directory"]))
+    min_age_days = float(rules.get("min_age_days", 0) or 0)
+    min_size_mb = float(rules.get("min_size_mb", 0) or 0)
+    min_age_seconds = min_age_days * 24 * 60 * 60
+    min_size_bytes = min_size_mb * 1024 * 1024
+    max_items = int(cleanup_config.get("max_items_per_run", 500) or 500)
+    max_runtime_seconds = float(cleanup_config.get("max_runtime_seconds", 120) or 120)
+
+    candidates: List[Dict[str, Any]] = []
+    deadline = now + max_runtime_seconds
+    directory_stack = [normalized_mount_point]
+
+    while directory_stack and len(candidates) < max_items and now <= deadline:
+        current_dir = directory_stack.pop()
+        if _is_protected_path(current_dir, protected_paths):
+            continue
+
+        with os.scandir(current_dir) as entries:
+            for entry in entries:
+                entry_path = os.path.realpath(entry.path)
+                if not _is_within_mount_boundary(entry_path, normalized_mount_point):
+                    continue
+                if entry.is_symlink():
+                    continue
+                if _is_protected_path(entry_path, protected_paths):
+                    continue
+                if _matches_any_selector(entry_path, exclude_selectors):
+                    continue
+
+                is_dir = entry.is_dir(follow_symlinks=False)
+                if is_dir:
+                    directory_stack.append(entry_path)
+
+                if not _matches_any_selector(entry_path, include_selectors):
+                    continue
+
+                stat_result = entry.stat(follow_symlinks=False)
+                age_seconds = max(0.0, now - stat_result.st_mtime)
+                if age_seconds < min_age_seconds:
+                    continue
+                if stat_result.st_size < min_size_bytes:
+                    continue
+
+                if is_dir and "directory" not in file_types:
+                    continue
+                if not is_dir and "file" not in file_types:
+                    continue
+
+                candidates.append(
+                    {
+                        "path": entry_path,
+                        "type": "directory" if is_dir else "file",
+                        "size_bytes": stat_result.st_size,
+                    }
+                )
+                if len(candidates) >= max_items:
+                    break
+
+    return candidates
+
+
+def quarantine_cleanup_candidates(
+    candidates: List[Dict[str, Any]],
+    cleanup_config: Dict[str, Any],
+    mount_point: str,
+    run_id: str,
+    current_time: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Move candidates into quarantine and write a restore manifest for the run."""
+    now = time.time() if current_time is None else current_time
+    quarantine_root = os.path.realpath(cleanup_config["quarantine_dir"])
+    normalized_mount_point = os.path.realpath(mount_point)
+    errors: List[Dict[str, str]] = []
+    quarantined: List[Dict[str, Any]] = []
+    manifest_path = os.path.join(quarantine_root, "manifests", f"{run_id}.json")
+
+    os.makedirs(quarantine_root, exist_ok=True)
+
+    if cleanup_config.get("safety", {}).get("require_quarantine_same_filesystem", True):
+        mount_stat = os.stat(normalized_mount_point)
+        quarantine_stat = os.stat(quarantine_root)
+        if mount_stat.st_dev != quarantine_stat.st_dev:
+            return {
+                "quarantined": [],
+                "errors": [
+                    {
+                        "path": normalized_mount_point,
+                        "reason": "Quarantine directory must reside on the same filesystem as the cleanup target",
+                    }
+                ],
+                "manifest_path": manifest_path,
+            }
+
+    items_root = os.path.join(quarantine_root, "items", run_id)
+    os.makedirs(items_root, exist_ok=True)
+
+    for index, candidate in enumerate(candidates, start=1):
+        source_path = os.path.realpath(candidate["path"])
+        item_type = candidate.get("type", "file")
+
+        if item_type == "directory" and not cleanup_config.get("allow_directories", False):
+            errors.append({"path": source_path, "reason": "Directory cleanup is disabled"})
+            continue
+
+        destination_name = f"{index:06d}_{os.path.basename(source_path) or 'item'}"
+        destination_path = os.path.join(items_root, destination_name)
+
+        try:
+            shutil.move(source_path, destination_path)
+        except OSError as exc:
+            errors.append({"path": source_path, "reason": str(exc)})
+            continue
+
+        quarantined.append(
+            {
+                "item_id": destination_name,
+                "original_path": source_path,
+                "quarantine_path": destination_path,
+                "item_type": item_type,
+                "size_bytes": int(candidate.get("size_bytes", 0) or 0),
+                "quarantined_at": now,
+            }
+        )
+
+    if quarantined:
+        os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
+        manifest_payload = {
+            "run_id": run_id,
+            "mount_point": normalized_mount_point,
+            "quarantine_dir": quarantine_root,
+            "generated_at": now,
+            "items": quarantined,
+        }
+        with open(manifest_path, "w", encoding="utf-8") as manifest_file:
+            json.dump(manifest_payload, manifest_file, indent=2, sort_keys=True)
+            manifest_file.write("\n")
+
+    return {"quarantined": quarantined, "errors": errors, "manifest_path": manifest_path}
+
+
+def purge_quarantine_items(
+    cleanup_config: Dict[str, Any],
+    current_time: Optional[float] = None,
+    retention_seconds: int = 0,
+    dry_run: bool = False,
+) -> Dict[str, List[str]]:
+    """Delete expired quarantined items referenced by run manifests."""
+    now = time.time() if current_time is None else current_time
+    quarantine_root = os.path.realpath(cleanup_config["quarantine_dir"])
+    manifests_dir = os.path.join(quarantine_root, "manifests")
+    deleted_paths: List[str] = []
+    eligible_paths: List[str] = []
+
+    if not os.path.isdir(manifests_dir):
+        return {"eligible_paths": [], "deleted_paths": []}
+
+    for entry in sorted(os.scandir(manifests_dir), key=lambda item: item.name):
+        if not entry.is_file() or not entry.name.endswith(".json"):
+            continue
+
+        with open(entry.path, "r", encoding="utf-8") as manifest_file:
+            manifest_payload = json.load(manifest_file)
+
+        generated_at = float(manifest_payload.get("generated_at", 0) or 0)
+        if now - generated_at < retention_seconds:
+            continue
+
+        manifest_deleted_paths: List[str] = []
+        for item in manifest_payload.get("items", []):
+            quarantine_path = os.path.realpath(item["quarantine_path"])
+            if not _is_within_mount_boundary(quarantine_path, quarantine_root):
+                continue
+            eligible_paths.append(quarantine_path)
+            if dry_run or not os.path.exists(quarantine_path):
+                continue
+
+            if os.path.isdir(quarantine_path):
+                shutil.rmtree(quarantine_path)
+            else:
+                os.remove(quarantine_path)
+            deleted_paths.append(quarantine_path)
+            manifest_deleted_paths.append(quarantine_path)
+
+        if not dry_run and manifest_deleted_paths:
+            os.remove(entry.path)
+
+    return {"eligible_paths": eligible_paths, "deleted_paths": deleted_paths}
+
+
+def restore_quarantine_manifest(manifest_path: str, dry_run: bool = False) -> Dict[str, Any]:
+    """Restore quarantined items from a run manifest back to their original paths."""
+    restored_paths: List[str] = []
+    errors: List[Dict[str, str]] = []
+
+    with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+        manifest_payload = json.load(manifest_file)
+
+    for item in manifest_payload.get("items", []):
+        original_path = item["original_path"]
+        quarantine_path = item["quarantine_path"]
+
+        if os.path.exists(original_path):
+            errors.append({"path": original_path, "reason": "Destination already exists"})
+            continue
+        if not os.path.exists(quarantine_path):
+            errors.append({"path": quarantine_path, "reason": "Quarantine item is missing"})
+            continue
+
+        if dry_run:
+            restored_paths.append(original_path)
+            continue
+
+        os.makedirs(os.path.dirname(original_path), exist_ok=True)
+        shutil.move(quarantine_path, original_path)
+        restored_paths.append(original_path)
+
+    if not dry_run and restored_paths and not errors:
+        os.remove(manifest_path)
+
+    return {"restored_paths": restored_paths, "errors": errors}
+
+
+def restore_quarantine_directory(quarantine_dir: str, dry_run: bool = False) -> Dict[str, Any]:
+    """Restore every manifest currently stored under a quarantine directory."""
+    manifests_dir = os.path.join(os.path.realpath(quarantine_dir), "manifests")
+    restored_paths: List[str] = []
+    errors: List[Dict[str, str]] = []
+
+    if not os.path.isdir(manifests_dir):
+        return {"restored_paths": [], "errors": []}
+
+    for entry in sorted(os.scandir(manifests_dir), key=lambda item: item.name):
+        if not entry.is_file() or not entry.name.endswith(".json"):
+            continue
+
+        result = restore_quarantine_manifest(entry.path, dry_run=dry_run)
+        restored_paths.extend(result.get("restored_paths", []))
+        errors.extend(result.get("errors", []))
+
+    return {"restored_paths": restored_paths, "errors": errors}
+
+
+def _matches_any_selector(path: str, selectors: List[Dict[str, str]]) -> bool:
+    """Return True when the path matches any selector in the list."""
+    if not selectors:
+        return False
+    return any(path_matches_selector(path, selector) for selector in selectors)
+
+
+def _is_protected_path(path: str, protected_paths: set[str]) -> bool:
+    """Return True when a path is equal to or nested under a protected path."""
+    for protected in protected_paths:
+        if path == protected:
+            return True
+        if protected == os.sep:
+            continue
+        if path.startswith(f"{protected}{os.sep}"):
+            return True
+    return False
+
+
+def _is_within_mount_boundary(path: str, mount_point: str) -> bool:
+    """Return True when a path is equal to or nested under the target mount point."""
+    return path == mount_point or path.startswith(f"{mount_point}{os.sep}")

--- a/src/xnetvn_monitord/monitors/resource_monitor.py
+++ b/src/xnetvn_monitord/monitors/resource_monitor.py
@@ -28,6 +28,11 @@ from typing import Any, Dict, List, Optional
 
 import psutil
 
+from xnetvn_monitord.monitors.disk_cleanup import (
+    normalize_cleanup_config,
+    quarantine_cleanup_candidates,
+    scan_cleanup_candidates,
+)
 from xnetvn_monitord.utils.service_manager import ServiceManager
 
 logger = logging.getLogger(__name__)
@@ -97,7 +102,7 @@ class ResourceMonitor:
                 disk_result = self._check_disk(disk_config)
                 results["disk"] = disk_result
                 if disk_result.get("threshold_exceeded"):
-                    action_result = self._handle_low_disk()
+                    action_result = self._handle_low_disk(disk_result)
                     results["actions_taken"].append("low_disk_recovery")
                     if action_result:
                         results["action_results"].append(action_result)
@@ -433,27 +438,95 @@ class ResourceMonitor:
             },
         }
 
-    def _handle_low_disk(self) -> Optional[Dict]:
-        """Handle low disk space by restarting configured services."""
+    def _handle_low_disk(self, disk_result: Optional[Dict] = None) -> Optional[Dict]:
+        """Handle low disk space with optional cleanup and service recovery."""
         if not self._check_action_cooldown("low_disk"):
             logger.info("Low disk recovery is in cooldown period")
             return None
 
         logger.info("Executing low disk recovery actions")
+        disk_config = self.config.get("disk", {})
+        action_on_threshold = str(disk_config.get("action_on_threshold", "notify")).lower()
         recovery_config = self.config.get("recovery_actions", {})
-        services = recovery_config.get("low_disk_services", [])
-        service_results = self._restart_services(services, recovery_config)
+        service_results: List[Dict[str, Any]] = []
+        cleanup_result: Optional[Dict[str, Any]] = None
+
+        if action_on_threshold in {"cleanup", "both"}:
+            cleanup_result = self._execute_disk_cleanup(disk_result or {"mount_points": []})
+
+        if action_on_threshold in {"notify", "both"}:
+            services = recovery_config.get("low_disk_services", [])
+            service_results = self._restart_services(services, recovery_config)
+
         self._update_action_cooldown("low_disk")
-        success = all(result.get("success", False) for result in service_results) if service_results else True
+        success = True
+        if cleanup_result is not None:
+            success = success and cleanup_result.get("success", False)
+        if service_results:
+            success = success and all(result.get("success", False) for result in service_results)
 
         return {
             "action": "low_disk_recovery",
             "timestamp": time.time(),
             "success": success,
             "details": {
+                "cleanup": cleanup_result,
                 "services": service_results,
             },
         }
+
+    def _execute_disk_cleanup(self, disk_result: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute disk cleanup for mount points that exceeded configured thresholds."""
+        disk_config = self.config.get("disk", {})
+        cleanup_config = disk_config.get("cleanup", {})
+        if not cleanup_config.get("enabled", False):
+            return {
+                "success": False,
+                "mounts": [],
+                "errors": ["Disk cleanup is not enabled"],
+            }
+
+        normalized_cleanup_config = normalize_cleanup_config(cleanup_config)
+        mount_results: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        current_time = time.time()
+
+        for index, mount_point in enumerate(disk_result.get("mount_points", []), start=1):
+            if not mount_point.get("threshold_exceeded"):
+                continue
+
+            mount_path = mount_point.get("path")
+            if not mount_path:
+                continue
+
+            try:
+                candidates = scan_cleanup_candidates(
+                    mount_path,
+                    normalized_cleanup_config,
+                    current_time=current_time,
+                )
+                quarantine_result = quarantine_cleanup_candidates(
+                    candidates,
+                    normalized_cleanup_config,
+                    mount_point=mount_path,
+                    run_id=f"disk-cleanup-{int(current_time)}-{index}",
+                    current_time=current_time,
+                )
+                mount_results.append(
+                    {
+                        "path": mount_path,
+                        "candidates_found": len(candidates),
+                        "quarantined_count": len(quarantine_result.get("quarantined", [])),
+                        "errors": quarantine_result.get("errors", []),
+                        "manifest_path": quarantine_result.get("manifest_path"),
+                    }
+                )
+            except Exception as exc:
+                logger.error("Error executing disk cleanup for %s: %s", mount_path, str(exc))
+                errors.append(f"{mount_path}: {str(exc)}")
+
+        success = not errors and all(not item.get("errors") for item in mount_results)
+        return {"success": success, "mounts": mount_results, "errors": errors}
 
     def _restart_services(self, services: List[str], config: Dict) -> List[Dict]:
         """Restart a list of services.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,15 @@ This module provides shared fixtures and configuration for all tests.
 
 import logging
 import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import Dict, Generator
 
 import pytest
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_restore_quarantine.py
+++ b/tests/test_restore_quarantine.py
@@ -1,0 +1,90 @@
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_restore_quarantine_script_restores_manifest(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "restore_quarantine.sh"
+    install_dir = tmp_path / "install"
+    package_dir = install_dir / "xnetvn_monitord"
+    source_package_dir = repo_root / "src" / "xnetvn_monitord"
+    shutil.copytree(source_package_dir, package_dir)
+
+    quarantine_dir = install_dir / ".local" / "quarantine"
+    manifest_dir = quarantine_dir / "manifests"
+    items_dir = quarantine_dir / "items" / "run-restore"
+    manifest_dir.mkdir(parents=True)
+    items_dir.mkdir(parents=True)
+
+    original_path = tmp_path / "restore-target" / "candidate.log"
+    quarantine_path = items_dir / "000001_candidate.log"
+    quarantine_path.write_text("payload", encoding="utf-8")
+
+    manifest_path = manifest_dir / "run-restore.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "run_id": "run-restore",
+                "generated_at": 1_000_000,
+                "items": [
+                    {
+                        "original_path": str(original_path),
+                        "quarantine_path": str(quarantine_path),
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            "bash",
+            str(script_path),
+            "--install-dir",
+            str(install_dir),
+            "--manifest",
+            str(manifest_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if proc.returncode != 0:
+        print("STDOUT:\n", proc.stdout)
+        print("STDERR:\n", proc.stderr, file=sys.stderr)
+
+    assert proc.returncode == 0
+    assert original_path.read_text(encoding="utf-8") == "payload"
+    assert quarantine_path.exists() is False
+    assert manifest_path.exists() is False
+
+
+def test_restore_quarantine_script_fails_for_missing_manifest(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "restore_quarantine.sh"
+    install_dir = tmp_path / "install"
+    package_dir = install_dir / "xnetvn_monitord"
+    source_package_dir = repo_root / "src" / "xnetvn_monitord"
+    shutil.copytree(source_package_dir, package_dir)
+
+    missing_manifest = tmp_path / "missing.json"
+    proc = subprocess.run(
+        [
+            "bash",
+            str(script_path),
+            "--install-dir",
+            str(install_dir),
+            "--manifest",
+            str(missing_manifest),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode != 0
+    assert "Manifest file not found" in proc.stderr

--- a/tests/unit/test_disk_cleanup.py
+++ b/tests/unit/test_disk_cleanup.py
@@ -1,0 +1,806 @@
+# Copyright 2026 xNetVN Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for disk cleanup safety and configuration helpers."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from xnetvn_monitord.monitors.disk_cleanup import purge_quarantine_items  # noqa: E402
+from xnetvn_monitord.monitors.disk_cleanup import quarantine_cleanup_candidates  # noqa: E402
+from xnetvn_monitord.monitors.disk_cleanup import restore_quarantine_directory  # noqa: E402
+from xnetvn_monitord.monitors.disk_cleanup import restore_quarantine_manifest  # noqa: E402
+from xnetvn_monitord.monitors.disk_cleanup import (  # noqa: E402
+    DEFAULT_PROTECTED_PATHS,
+    normalize_cleanup_config,
+    path_matches_selector,
+    scan_cleanup_candidates,
+)
+
+
+class TestDiskCleanupConfigNormalization:
+    """Tests for cleanup config normalization and selector validation."""
+
+    def test_should_accept_exact_regex_and_glob_selectors(self):
+        """Supported selector types should normalize without errors."""
+        config = {
+            "enabled": True,
+            "mode": "quarantine_then_delete",
+            "selectors": {
+                "include": [
+                    {"type": "exact", "pattern": "/var/log/app.log"},
+                    {"type": "regex", "pattern": r"^/var/tmp/.+"},
+                    {"type": "glob", "pattern": "/home/*/.cache/**"},
+                ],
+                "exclude": [],
+            },
+            "safety": {},
+        }
+
+        normalized = normalize_cleanup_config(config)
+
+        assert [item["type"] for item in normalized["selectors"]["include"]] == ["exact", "regex", "glob"]
+
+    def test_should_reject_invalid_selector_type(self):
+        """Unsupported selector types must be rejected."""
+        config = {
+            "mode": "quarantine_then_delete",
+            "selectors": {
+                "include": [{"type": "prefix", "pattern": "/tmp"}],
+                "exclude": [],
+            },
+            "safety": {},
+        }
+
+        with pytest.raises(ValueError, match="Unsupported selector type"):
+            normalize_cleanup_config(config)
+
+    def test_should_reject_invalid_regex_selector(self):
+        """Broken regular expressions must be rejected during normalization."""
+        config = {
+            "mode": "quarantine_then_delete",
+            "selectors": {
+                "include": [{"type": "regex", "pattern": r"[unterminated"}],
+                "exclude": [],
+            },
+            "safety": {},
+        }
+
+        with pytest.raises(ValueError, match="Invalid regex selector"):
+            normalize_cleanup_config(config)
+
+    def test_should_merge_builtin_protected_paths_with_configured_entries(self):
+        """Built-in protected paths should always remain active."""
+        config = {
+            "mode": "quarantine_then_delete",
+            "selectors": {"include": [], "exclude": []},
+            "safety": {"protected_paths": ["/srv/important"]},
+        }
+
+        normalized = normalize_cleanup_config(config)
+
+        for protected_path in DEFAULT_PROTECTED_PATHS:
+            assert protected_path in normalized["safety"]["protected_paths"]
+        assert "/srv/important" in normalized["safety"]["protected_paths"]
+
+    def test_should_reject_unsupported_cleanup_mode(self):
+        """Unsupported cleanup modes must be rejected during normalization."""
+        with pytest.raises(ValueError, match="Unsupported cleanup mode"):
+            normalize_cleanup_config({"mode": "delete_immediately"})
+
+    def test_should_reject_empty_selector_pattern(self):
+        """Selector patterns must be non-empty strings."""
+        with pytest.raises(ValueError, match="Selector pattern must be a non-empty string"):
+            normalize_cleanup_config(
+                {
+                    "mode": "quarantine_then_delete",
+                    "selectors": {"include": [{"type": "glob", "pattern": ""}], "exclude": []},
+                }
+            )
+
+
+class TestDiskCleanupPathSelection:
+    """Tests for selector matching and safe candidate scanning."""
+
+    def test_should_match_exact_path_case_sensitively(self):
+        """Exact matches must remain case-sensitive."""
+        selector = {"type": "exact", "pattern": "/var/log/App.LOG"}
+
+        assert path_matches_selector("/var/log/App.LOG", selector) is True
+        assert path_matches_selector("/var/log/app.log", selector) is False
+
+    def test_should_match_regex_against_normalized_absolute_path(self):
+        """Regex selectors should evaluate against the normalized absolute path."""
+        selector = {"type": "regex", "pattern": r"^/srv/cache/.+\.tmp$"}
+
+        assert path_matches_selector("/srv/cache/file.tmp", selector) is True
+        assert path_matches_selector("/srv/cache/file.log", selector) is False
+
+    def test_should_match_glob_against_normalized_absolute_path(self):
+        """Glob selectors should support shell-style absolute path matching."""
+        selector = {"type": "glob", "pattern": "/home/*/.cache/**"}
+
+        assert path_matches_selector("/home/alice/.cache/pip/http-v2", selector) is True
+        assert path_matches_selector("/home/alice/cache/pip/http-v2", selector) is False
+
+    def test_should_raise_when_matching_unknown_selector_type_directly(self):
+        """Direct selector matching should still reject unknown selector types."""
+        with pytest.raises(ValueError, match="Unsupported selector type"):
+            path_matches_selector("/tmp/file.log", {"type": "prefix", "pattern": "/tmp"})
+
+    def test_should_skip_excluded_paths_before_descending(self, tmp_path):
+        """Excluded directories should be pruned before their children are scanned."""
+        root_path = tmp_path / "mount"
+        included_dir = root_path / "cache"
+        excluded_dir = root_path / "skip-me"
+        included_dir.mkdir(parents=True)
+        excluded_dir.mkdir(parents=True)
+        (included_dir / "keep.log").write_text("x" * 1024, encoding="utf-8")
+        (excluded_dir / "skip.log").write_text("x" * 1024, encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "selectors": {
+                    "include": [{"type": "glob", "pattern": f"{root_path}/**"}],
+                    "exclude": [{"type": "glob", "pattern": f"{excluded_dir}/**"}],
+                },
+                "rules": {"min_age_days": 0, "min_size_mb": 0, "file_types": ["file"]},
+                "safety": {},
+            }
+        )
+
+        candidates = scan_cleanup_candidates(str(root_path), cleanup_config, current_time=1_000_000)
+
+        assert str(included_dir / "keep.log") in [item["path"] for item in candidates]
+        assert str(excluded_dir / "skip.log") not in [item["path"] for item in candidates]
+
+    def test_should_skip_protected_paths(self, tmp_path):
+        """Protected paths must never appear in cleanup candidates."""
+        root_path = tmp_path / "mount"
+        protected_dir = root_path / "protected"
+        protected_dir.mkdir(parents=True)
+        protected_file = protected_dir / "secret.log"
+        protected_file.write_text("x" * 1024, encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "selectors": {
+                    "include": [{"type": "glob", "pattern": f"{root_path}/**"}],
+                    "exclude": [],
+                },
+                "rules": {"min_age_days": 0, "min_size_mb": 0, "file_types": ["file"]},
+                "safety": {"protected_paths": [str(protected_dir)]},
+            }
+        )
+
+        candidates = scan_cleanup_candidates(str(root_path), cleanup_config, current_time=1_000_000)
+
+        assert str(protected_file) not in [item["path"] for item in candidates]
+
+    def test_should_skip_symlink_targets(self, tmp_path):
+        """Symlinked entries must not be scanned as cleanup candidates."""
+        root_path = tmp_path / "mount"
+        root_path.mkdir(parents=True)
+        target_file = tmp_path / "outside.log"
+        target_file.write_text("x" * 1024, encoding="utf-8")
+        symlink_path = root_path / "outside-link.log"
+        symlink_path.symlink_to(target_file)
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "selectors": {
+                    "include": [{"type": "glob", "pattern": f"{root_path}/**"}],
+                    "exclude": [],
+                },
+                "rules": {"min_age_days": 0, "min_size_mb": 0, "file_types": ["file"]},
+                "safety": {},
+            }
+        )
+
+        candidates = scan_cleanup_candidates(str(root_path), cleanup_config, current_time=1_000_000)
+
+        assert str(symlink_path) not in [item["path"] for item in candidates]
+
+    def test_should_skip_paths_outside_mount_boundary(self, tmp_path):
+        """Candidate scanning must never escape the target mount root."""
+        mount_root = tmp_path / "mount"
+        outside_root = tmp_path / "outside"
+        mount_root.mkdir(parents=True)
+        outside_root.mkdir(parents=True)
+        inside_file = mount_root / "inside.log"
+        outside_file = outside_root / "outside.log"
+        inside_file.write_text("x" * 1024, encoding="utf-8")
+        outside_file.write_text("x" * 1024, encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "selectors": {
+                    "include": [
+                        {"type": "glob", "pattern": f"{mount_root}/**"},
+                        {"type": "glob", "pattern": f"{outside_root}/**"},
+                    ],
+                    "exclude": [],
+                },
+                "rules": {"min_age_days": 0, "min_size_mb": 0, "file_types": ["file"]},
+                "safety": {"require_same_filesystem_as_mount_point": True},
+            }
+        )
+
+        candidates = scan_cleanup_candidates(str(mount_root), cleanup_config, current_time=1_000_000)
+
+        assert str(inside_file) in [item["path"] for item in candidates]
+        assert str(outside_file) not in [item["path"] for item in candidates]
+
+    def test_should_return_no_candidates_when_include_selectors_are_empty(self, tmp_path):
+        """A scan without include selectors must fail closed and return no candidates."""
+        mount_root = tmp_path / "mount"
+        mount_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "selectors": {"include": [], "exclude": []},
+                "rules": {"min_age_days": 0, "min_size_mb": 0, "file_types": ["file"]},
+                "safety": {},
+            }
+        )
+
+        assert scan_cleanup_candidates(str(mount_root), cleanup_config, current_time=1_000_000) == []
+
+    def test_should_enforce_min_age_and_min_size_rules(self, tmp_path):
+        """Candidates below age or size thresholds must be skipped."""
+        mount_root = tmp_path / "mount"
+        mount_root.mkdir(parents=True)
+        young_file = mount_root / "young.log"
+        small_file = mount_root / "small.log"
+        eligible_file = mount_root / "eligible.log"
+        young_file.write_text("payload" * 1024, encoding="utf-8")
+        small_file.write_text("tiny", encoding="utf-8")
+        eligible_file.write_text("payload" * 1024, encoding="utf-8")
+        os.utime(young_file, (1_000_000, 1_000_000))
+        os.utime(small_file, (1_000_000 - 10 * 24 * 60 * 60, 1_000_000 - 10 * 24 * 60 * 60))
+        os.utime(eligible_file, (1_000_000 - 10 * 24 * 60 * 60, 1_000_000 - 10 * 24 * 60 * 60))
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "selectors": {"include": [{"type": "glob", "pattern": f"{mount_root}/**"}], "exclude": []},
+                "rules": {"min_age_days": 7, "min_size_mb": 0.001, "file_types": ["file"]},
+                "safety": {},
+            }
+        )
+
+        candidates = scan_cleanup_candidates(str(mount_root), cleanup_config, current_time=1_000_000)
+
+        assert [item["path"] for item in candidates] == [str(eligible_file)]
+
+
+class TestDiskCleanupQuarantine:
+    """Tests for quarantine move safety and manifest generation."""
+
+    def test_should_require_quarantine_on_same_filesystem_when_configured(self, tmp_path, mocker):
+        """Quarantine should fail closed when filesystem affinity is required and violated."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("x" * 1024, encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": True},
+            }
+        )
+        real_os_stat = os.stat
+
+        def fake_os_stat(path, *args, **kwargs):
+            normalized_path = os.path.realpath(path)
+            if normalized_path == os.path.realpath(mount_root):
+                stat_result = real_os_stat(path, *args, **kwargs)
+                return SimpleNamespace(st_dev=100, st_mode=stat_result.st_mode)
+            if normalized_path == os.path.realpath(quarantine_root):
+                stat_result = real_os_stat(path, *args, **kwargs)
+                return SimpleNamespace(st_dev=200, st_mode=stat_result.st_mode)
+            return real_os_stat(path, *args, **kwargs)
+
+        mocker.patch("xnetvn_monitord.monitors.disk_cleanup.os.stat", side_effect=fake_os_stat)
+
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-001",
+            current_time=1_000_000,
+        )
+
+        assert result["quarantined"] == []
+        assert result["errors"]
+        assert candidate.exists() is True
+
+    def test_should_move_file_into_quarantine_and_record_manifest(self, tmp_path):
+        """Eligible files should be moved into quarantine and written to the run manifest."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-002",
+            current_time=1_000_000,
+        )
+
+        assert candidate.exists() is False
+        assert result["quarantined"][0]["original_path"] == str(candidate)
+        assert Path(result["quarantined"][0]["quarantine_path"]).exists() is True
+        assert Path(result["manifest_path"]).exists() is True
+
+    def test_should_move_directory_into_quarantine_when_allowed(self, tmp_path):
+        """Directories should be quarantined when the config allows directory cleanup."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        candidate_dir = mount_root / "cache-dir"
+        candidate_dir.mkdir(parents=True)
+        (candidate_dir / "cached.bin").write_text("payload", encoding="utf-8")
+        quarantine_root.mkdir(parents=True)
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "allow_directories": True,
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate_dir), "type": "directory", "size_bytes": 0}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-003",
+            current_time=1_000_000,
+        )
+
+        assert candidate_dir.exists() is False
+        assert result["quarantined"][0]["item_type"] == "directory"
+
+    def test_should_refuse_directory_quarantine_when_disallowed(self, tmp_path):
+        """Directory candidates must be rejected unless explicitly enabled."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        candidate_dir = mount_root / "cache-dir"
+        candidate_dir.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "allow_directories": False,
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate_dir), "type": "directory", "size_bytes": 0}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-004",
+            current_time=1_000_000,
+        )
+
+        assert candidate_dir.exists() is True
+        assert result["quarantined"] == []
+        assert result["errors"]
+
+    def test_should_preserve_original_path_in_manifest(self, tmp_path):
+        """Manifest data should keep the exact original absolute path for restore."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "nested" / "candidate.log"
+        candidate.parent.mkdir(parents=True)
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-005",
+            current_time=1_000_000,
+        )
+
+        assert result["quarantined"][0]["original_path"] == str(candidate)
+
+    def test_should_not_fallback_to_direct_delete_when_quarantine_move_fails(self, tmp_path, mocker):
+        """A failed quarantine move must not trigger any live-path deletion fallback."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        mocker.patch("shutil.move", side_effect=OSError("move failed"))
+
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-006",
+            current_time=1_000_000,
+        )
+
+        assert candidate.exists() is True
+        assert result["quarantined"] == []
+        assert result["errors"]
+
+
+class TestDiskCleanupPurgeAndRestore:
+    """Tests for quarantine purge retention and restore workflows."""
+
+    def test_should_purge_only_expired_quarantine_items(self, tmp_path):
+        """Purge should only delete quarantined items older than the configured retention."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        old_candidate = mount_root / "old.log"
+        fresh_candidate = mount_root / "fresh.log"
+        old_candidate.write_text("old", encoding="utf-8")
+        fresh_candidate.write_text("fresh", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        old_result = quarantine_cleanup_candidates(
+            [{"path": str(old_candidate), "type": "file", "size_bytes": old_candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-old",
+            current_time=1_000_000,
+        )
+        fresh_result = quarantine_cleanup_candidates(
+            [{"path": str(fresh_candidate), "type": "file", "size_bytes": fresh_candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-fresh",
+            current_time=1_000_000 + 60,
+        )
+
+        purge_result = purge_quarantine_items(
+            cleanup_config,
+            current_time=1_000_000 + 120,
+            retention_seconds=90,
+            dry_run=False,
+        )
+
+        assert Path(old_result["quarantined"][0]["quarantine_path"]).exists() is False
+        assert Path(fresh_result["quarantined"][0]["quarantine_path"]).exists() is True
+        assert old_result["quarantined"][0]["quarantine_path"] in purge_result["deleted_paths"]
+        assert fresh_result["quarantined"][0]["quarantine_path"] not in purge_result["deleted_paths"]
+
+    def test_should_not_delete_anything_during_purge_dry_run(self, tmp_path):
+        """Dry-run purge should report candidates without deleting quarantine data."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-dry",
+            current_time=1_000_000,
+        )
+
+        purge_result = purge_quarantine_items(
+            cleanup_config,
+            current_time=1_000_000 + 120,
+            retention_seconds=90,
+            dry_run=True,
+        )
+
+        assert Path(result["quarantined"][0]["quarantine_path"]).exists() is True
+        assert result["quarantined"][0]["quarantine_path"] in purge_result["eligible_paths"]
+        assert purge_result["deleted_paths"] == []
+
+    def test_should_handle_missing_quarantine_items_during_purge(self, tmp_path):
+        """Purge should list missing items as eligible without failing or deleting anything else."""
+        quarantine_root = tmp_path / "quarantine"
+        manifest_dir = quarantine_root / "manifests"
+        manifest_dir.mkdir(parents=True)
+        missing_path = quarantine_root / "items" / "run-missing" / "missing.log"
+        manifest_path = manifest_dir / "run-missing.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "generated_at": 1_000_000,
+                    "items": [{"quarantine_path": str(missing_path)}],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        cleanup_config = normalize_cleanup_config(
+            {"mode": "quarantine_then_delete", "quarantine_dir": str(quarantine_root), "safety": {}}
+        )
+
+        purge_result = purge_quarantine_items(
+            cleanup_config,
+            current_time=1_000_100,
+            retention_seconds=60,
+            dry_run=False,
+        )
+
+        assert str(missing_path) in purge_result["eligible_paths"]
+        assert purge_result["deleted_paths"] == []
+
+    def test_should_delete_quarantined_directories_during_purge(self, tmp_path):
+        """Expired quarantined directories should be removed recursively."""
+        quarantine_root = tmp_path / "quarantine"
+        manifest_dir = quarantine_root / "manifests"
+        directory_path = quarantine_root / "items" / "run-dir" / "cache-dir"
+        directory_path.mkdir(parents=True)
+        (directory_path / "cached.bin").write_text("payload", encoding="utf-8")
+        manifest_dir.mkdir(parents=True)
+        manifest_path = manifest_dir / "run-dir.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "generated_at": 1_000_000,
+                    "items": [{"quarantine_path": str(directory_path)}],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        cleanup_config = normalize_cleanup_config(
+            {"mode": "quarantine_then_delete", "quarantine_dir": str(quarantine_root), "safety": {}}
+        )
+
+        purge_result = purge_quarantine_items(
+            cleanup_config,
+            current_time=1_000_100,
+            retention_seconds=60,
+            dry_run=False,
+        )
+
+        assert str(directory_path) in purge_result["deleted_paths"]
+        assert directory_path.exists() is False
+
+    def test_should_report_restore_targets_during_dry_run(self, tmp_path):
+        """Dry-run restore should report paths without moving files or deleting manifests."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("payload", encoding="utf-8")
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-dry-restore",
+            current_time=1_000_000,
+        )
+
+        restore_result = restore_quarantine_manifest(result["manifest_path"], dry_run=True)
+
+        assert restore_result["restored_paths"] == [str(candidate)]
+        assert Path(result["quarantined"][0]["quarantine_path"]).exists() is True
+        assert Path(result["manifest_path"]).exists() is True
+
+    def test_should_report_missing_quarantine_item_during_restore(self, tmp_path):
+        """Restore should report missing quarantine items without deleting the manifest."""
+        quarantine_root = tmp_path / "quarantine"
+        manifest_dir = quarantine_root / "manifests"
+        manifest_dir.mkdir(parents=True)
+        missing_path = quarantine_root / "items" / "run-missing" / "missing.log"
+        original_path = tmp_path / "restored" / "candidate.log"
+        manifest_path = manifest_dir / "run-missing.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "original_path": str(original_path),
+                            "quarantine_path": str(missing_path),
+                        }
+                    ]
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        restore_result = restore_quarantine_manifest(str(manifest_path), dry_run=False)
+
+        assert restore_result["restored_paths"] == []
+        assert restore_result["errors"]
+        assert manifest_path.exists() is True
+
+    def test_should_return_empty_restore_result_when_no_manifests_exist(self, tmp_path):
+        """Directory restore should return an empty result when no manifests directory exists."""
+        restore_result = restore_quarantine_directory(str(tmp_path / "quarantine"), dry_run=False)
+
+        assert restore_result == {"restored_paths": [], "errors": []}
+
+    def test_should_restore_quarantined_file_to_its_original_path(self, tmp_path):
+        """Restore should recreate the original parent path and move the file back."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "nested" / "candidate.log"
+        candidate.parent.mkdir(parents=True)
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-restore",
+            current_time=1_000_000,
+        )
+
+        restore_result = restore_quarantine_manifest(result["manifest_path"], dry_run=False)
+
+        assert candidate.exists() is True
+        assert candidate.read_text(encoding="utf-8") == "payload"
+        assert Path(result["quarantined"][0]["quarantine_path"]).exists() is False
+        assert restore_result["restored_paths"] == [str(candidate)]
+
+    def test_should_refuse_restore_when_destination_already_exists(self, tmp_path):
+        """Restore must fail closed when the live destination already exists."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        candidate = mount_root / "candidate.log"
+        candidate.write_text("payload", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        result = quarantine_cleanup_candidates(
+            [{"path": str(candidate), "type": "file", "size_bytes": candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-conflict",
+            current_time=1_000_000,
+        )
+        candidate.write_text("live-conflict", encoding="utf-8")
+
+        restore_result = restore_quarantine_manifest(result["manifest_path"], dry_run=False)
+
+        assert candidate.read_text(encoding="utf-8") == "live-conflict"
+        assert Path(result["quarantined"][0]["quarantine_path"]).exists() is True
+        assert restore_result["restored_paths"] == []
+        assert restore_result["errors"]
+
+    def test_should_restore_all_manifests_from_quarantine_directory(self, tmp_path):
+        """Directory restore should replay every manifest stored in the quarantine root."""
+        mount_root = tmp_path / "mount"
+        quarantine_root = tmp_path / "quarantine"
+        mount_root.mkdir(parents=True)
+        quarantine_root.mkdir(parents=True)
+        first_candidate = mount_root / "first.log"
+        second_candidate = mount_root / "second.log"
+        first_candidate.write_text("first", encoding="utf-8")
+        second_candidate.write_text("second", encoding="utf-8")
+
+        cleanup_config = normalize_cleanup_config(
+            {
+                "mode": "quarantine_then_delete",
+                "quarantine_dir": str(quarantine_root),
+                "safety": {"require_quarantine_same_filesystem": False},
+            }
+        )
+        quarantine_cleanup_candidates(
+            [{"path": str(first_candidate), "type": "file", "size_bytes": first_candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-1",
+            current_time=1_000_000,
+        )
+        quarantine_cleanup_candidates(
+            [{"path": str(second_candidate), "type": "file", "size_bytes": second_candidate.stat().st_size}],
+            cleanup_config,
+            mount_point=str(mount_root),
+            run_id="run-2",
+            current_time=1_000_001,
+        )
+
+        restore_result = restore_quarantine_directory(str(quarantine_root), dry_run=False)
+
+        assert first_candidate.read_text(encoding="utf-8") == "first"
+        assert second_candidate.read_text(encoding="utf-8") == "second"
+        assert restore_result["restored_paths"] == [str(first_candidate), str(second_candidate)]

--- a/tests/unit/test_resource_monitor.py
+++ b/tests/unit/test_resource_monitor.py
@@ -19,9 +19,13 @@ monitoring functionality.
 """
 
 import subprocess
+import sys
 import time
+from pathlib import Path
 
-from xnetvn_monitord.monitors.resource_monitor import ResourceMonitor
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from xnetvn_monitord.monitors.resource_monitor import ResourceMonitor  # noqa: E402
 
 
 class TestResourceMonitorInitialization:
@@ -852,6 +856,103 @@ class TestResourceMonitorAdditionalCoverage:
         monitor.last_action_time["low_disk"] = time.time()
 
         assert monitor._handle_low_disk() is None
+
+    def test_should_execute_disk_cleanup_without_restarting_services_in_cleanup_mode(self, mocker):
+        """Test cleanup mode runs disk cleanup but skips service restarts."""
+        monitor = ResourceMonitor(
+            {
+                "enabled": True,
+                "disk": {
+                    "action_on_threshold": "cleanup",
+                    "cleanup": {"enabled": True},
+                },
+                "recovery_actions": {"low_disk_services": ["mysql"]},
+            }
+        )
+        cleanup_result = {"success": True, "mounts": [{"path": "/", "candidates_found": 1, "quarantined_count": 1}]}
+        cleanup_mock = mocker.patch.object(monitor, "_execute_disk_cleanup", return_value=cleanup_result)
+        restart_mock = mocker.patch.object(monitor, "_restart_services", return_value=[{"success": True}])
+
+        result = monitor._handle_low_disk({"mount_points": [{"path": "/", "threshold_exceeded": True}]})
+
+        cleanup_mock.assert_called_once()
+        restart_mock.assert_not_called()
+        assert result["details"]["cleanup"] == cleanup_result
+        assert result["details"]["services"] == []
+
+    def test_should_execute_disk_cleanup_and_restart_services_in_both_mode(self, mocker):
+        """Test both mode runs disk cleanup and service restarts."""
+        monitor = ResourceMonitor(
+            {
+                "enabled": True,
+                "disk": {
+                    "action_on_threshold": "both",
+                    "cleanup": {"enabled": True},
+                },
+                "recovery_actions": {"low_disk_services": ["mysql"]},
+            }
+        )
+        cleanup_result = {"success": True, "mounts": [{"path": "/", "candidates_found": 1, "quarantined_count": 1}]}
+        cleanup_mock = mocker.patch.object(monitor, "_execute_disk_cleanup", return_value=cleanup_result)
+        restart_mock = mocker.patch.object(monitor, "_restart_services", return_value=[{"success": True}])
+
+        result = monitor._handle_low_disk({"mount_points": [{"path": "/", "threshold_exceeded": True}]})
+
+        cleanup_mock.assert_called_once()
+        restart_mock.assert_called_once_with(["mysql"], {"low_disk_services": ["mysql"]})
+        assert result["details"]["cleanup"] == cleanup_result
+        assert result["details"]["services"] == [{"success": True}]
+
+    def test_should_return_cleanup_disabled_error_when_cleanup_not_enabled(self):
+        """Disabled cleanup configuration should return a structured failure result."""
+        monitor = ResourceMonitor({"enabled": True, "disk": {"cleanup": {"enabled": False}}})
+
+        result = monitor._execute_disk_cleanup({"mount_points": [{"path": "/", "threshold_exceeded": True}]})
+
+        assert result == {"success": False, "mounts": [], "errors": ["Disk cleanup is not enabled"]}
+
+    def test_should_skip_mounts_without_threshold_or_path_when_executing_cleanup(self, mocker):
+        """Cleanup orchestration should ignore mount entries that are not actionable."""
+        monitor = ResourceMonitor(
+            {
+                "enabled": True,
+                "disk": {"cleanup": {"enabled": True, "mode": "quarantine_then_delete", "quarantine_dir": "/tmp/q"}},
+            }
+        )
+        scan_mock = mocker.patch("xnetvn_monitord.monitors.resource_monitor.scan_cleanup_candidates")
+        quarantine_mock = mocker.patch("xnetvn_monitord.monitors.resource_monitor.quarantine_cleanup_candidates")
+
+        result = monitor._execute_disk_cleanup(
+            {
+                "mount_points": [
+                    {"path": "/", "threshold_exceeded": False},
+                    {"threshold_exceeded": True},
+                ]
+            }
+        )
+
+        scan_mock.assert_not_called()
+        quarantine_mock.assert_not_called()
+        assert result == {"success": True, "mounts": [], "errors": []}
+
+    def test_should_record_cleanup_execution_errors_per_mount(self, mocker):
+        """Cleanup orchestration should surface per-mount exceptions in a structured way."""
+        monitor = ResourceMonitor(
+            {
+                "enabled": True,
+                "disk": {"cleanup": {"enabled": True, "mode": "quarantine_then_delete", "quarantine_dir": "/tmp/q"}},
+            }
+        )
+        mocker.patch(
+            "xnetvn_monitord.monitors.resource_monitor.scan_cleanup_candidates",
+            side_effect=RuntimeError("scan failed"),
+        )
+
+        result = monitor._execute_disk_cleanup({"mount_points": [{"path": "/", "threshold_exceeded": True}]})
+
+        assert result["success"] is False
+        assert result["mounts"] == []
+        assert result["errors"] == ["/: scan failed"]
 
     def test_should_handle_restart_services_exception(self, mocker):
         """Test restart services handles generic exceptions."""


### PR DESCRIPTION
## Summary
- add quarantine-first low-disk cleanup with exact/regex/glob selectors, protected path guards, bounded scans, manifests, purge helpers, and restore tooling
- integrate `resource_monitor.disk.action_on_threshold` so `cleanup` and `both` execute the new cleanup flow and ship an operator restore script in installs
- expand config comments, bilingual config docs, and regression coverage for cleanup orchestration and restore behavior

## Test Plan
- [x] `/home/udev/xdev/projects/githubcom/xnetvn-com/xnetvn_monitord/.venv/bin/python -m pytest -q` (`416 passed`, coverage `85.06%`)
- [x] `/home/udev/xdev/projects/githubcom/xnetvn-com/xnetvn_monitord/.venv/bin/python -m black --check src tests`
- [x] `/home/udev/xdev/projects/githubcom/xnetvn-com/xnetvn_monitord/.venv/bin/python -m isort --check-only src tests`
- [x] `/home/udev/xdev/projects/githubcom/xnetvn-com/xnetvn_monitord/.venv/bin/python -m flake8 src tests`
- [x] `shellcheck scripts/install.sh scripts/restore_quarantine.sh`

## Notes
- Repo-wide `mypy --install-types --non-interactive src` still reports a pre-existing error in `src/xnetvn_monitord/notifiers/__init__.py:987`, outside this feature scope.
